### PR TITLE
fixed it grabbing an object instead of the id(int value) 

### DIFF
--- a/terraform/aws/README.md
+++ b/terraform/aws/README.md
@@ -12,11 +12,14 @@ The latest version available can be located under the AWS Community AMIs, titled
 
 `Security-Onion-16.04`   
 
-*eu-central-1*: `ami-095b2f857622ecc34`  
-*eu-west-2*: `ami-05a57b5d7371e2110`  
-*us-east-2*: `ami-07dbe610064805440`  
-*us-west-2*: `ami-040bd1a2ba5e39e30`   
+The image is currently hosted in the following regions:
 
+`eu-central-1`      
+`eu-west-2`          
+`us-east-2`      
+`us-west-2`    
+
+If using Terraform, the correct image will be pulled upon the run of `terraform apply`.
 
 ### Configuring the Security Onion AMI and VPC Traffic Mirroring with Terraform
 Special thanks goes to Jonathan Johnson (@jsecurity101) and Dustin Lee (@dlee35),for their existing work on the base Terraform configuration and Security Onion additions!

--- a/terraform/aws/ubuntu.tf
+++ b/terraform/aws/ubuntu.tf
@@ -21,7 +21,7 @@ resource "aws_instance" "ubuntu_instance" {
   depends_on = [ null_resource.mirror_session_del_wait, aws_lambda_function.auto_mirror_lambda ]
   count         = var.ubuntu_hosts != 0 ? var.ubuntu_hosts : 0
   instance_type = var.ubuntu_instance_type
-  ami           = data.aws_ami.latest_ubuntu.id != "" ? data.aws_ami.latest_ubuntu : var.ubuntu_instance_ami
+  ami           = data.aws_ami.latest_ubuntu.id != "" ? data.aws_ami.latest_ubuntu.id : var.ubuntu_instance_ami
 
   tags = var.auto_mirror ? { Name = "ubuntu-${count.index}", Mirror = "True" } : { Name = "ubuntu-${count.index}" }
 

--- a/terraform/aws/ubuntu.tf
+++ b/terraform/aws/ubuntu.tf
@@ -35,3 +35,4 @@ resource "aws_instance" "ubuntu_instance" {
   }
 }
 
+ 

--- a/terraform/aws/windows.tf
+++ b/terraform/aws/windows.tf
@@ -21,7 +21,7 @@ resource "aws_instance" "windows_instance" {
   depends_on = [ null_resource.mirror_session_del_wait, aws_lambda_function.auto_mirror_lambda ]
   count         = var.windows_hosts != 0 ? var.windows_hosts : 0
   instance_type = var.windows_instance_type
-  ami           = data.aws_ami.latest_windows.id != "" ? data.aws_ami.latest_windows : var.windows_instance_ami
+  ami           = data.aws_ami.latest_windows.id != "" ? data.aws_ami.latest_windows.id : var.windows_instance_ami
 
   tags = var.auto_mirror ? { Name = "windows-${count.index}", Mirror = "True" } : { Name = "windows-${count.index}" }
 


### PR DESCRIPTION
Minor fixed in the `/terraform/aws/ubuntu.tf` and  `/terraform/aws/windows.tf`.

In line 24, if logic had yield object instead of image id, so it was causing an error, so added `.id` to grab numerical image value to assign ami variable.