### PR TITLE
Added id to the Terraform AWS EC2 instance creation.

### DIFF
--- a/terraform/aws/ubuntu.tf
+++ b/terraform/aws/ubuntu.tf
@@ -21,7 +21,7 @@ resource "aws_instance" "ubuntu_instance" {
   depends_on = [ null_resource.mirror_session_del_wait, aws_lambda_function.auto_mirror_lambda ]
   count         = var.ubuntu_hosts != 0 ? var.ubuntu_hosts : 0
   instance_type = var.ubuntu_instance_type
-  ami           = data.aws_ami.latest_ubuntu.id != "" ? data.aws_ami.latest_ubuntu : var.ubuntu_instance_ami
+  ami           = data.aws_ami.latest_ubuntu.id != "" ? data.aws_ami.latest_ubuntu.id : var.ubuntu_instance_ami
 
   tags = var.auto_mirror ? { Name = "ubuntu-${count.index}", Mirror = "True" } : { Name = "ubuntu-${count.index}" }
 

--- a/terraform/aws/windows.tf
+++ b/terraform/aws/windows.tf
@@ -21,7 +21,7 @@ resource "aws_instance" "windows_instance" {
   depends_on = [ null_resource.mirror_session_del_wait, aws_lambda_function.auto_mirror_lambda ]
   count         = var.windows_hosts != 0 ? var.windows_hosts : 0
   instance_type = var.windows_instance_type
-  ami           = data.aws_ami.latest_windows.id != "" ? data.aws_ami.latest_windows : var.windows_instance_ami
+  ami           = data.aws_ami.latest_windows.id != "" ? data.aws_ami.latest_windows.id : var.windows_instance_ami
 
   tags = var.auto_mirror ? { Name = "windows-${count.index}", Mirror = "True" } : { Name = "windows-${count.index}" }
 


### PR DESCRIPTION
During the creation of Windows and Ubuntu VM using the Terraform, it was outputting error, as it was grabbing the object. By adding the id, it was referencing correctly and was successfully created VMs. 